### PR TITLE
CoffeeScript on NPM has moved to "coffeescript (no hyphen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/shesek/iferr",
   "devDependencies": {
-    "coffee-script": "^1.12.7",
+    "coffeescript": "~2.3.1",
     "mocha": "^4.0.1"
   }
 }


### PR DESCRIPTION
Due to some deps we get deprecation warnings about coffeescript and the hyphen in between.
Maybe we could also update to the newest coffeescript version :). I am not a coffeescript user
so I am not sure if the new milestone version breaks anything.

Thanks in advance
Oliver